### PR TITLE
Handle missing source packages

### DIFF
--- a/lib/build-node.js
+++ b/lib/build-node.js
@@ -2,6 +2,7 @@ var format = require('util').format
 var fetch = require('./fetch')
 var Build = require('./build')().Build
 var Binary = require('./build')().Binary
+var NullBuild = require('./build-null')
 
 module.exports = function (name, baseUri) {
   var BuildNode = Object.create(Build, {
@@ -29,6 +30,13 @@ module.exports = function (name, baseUri) {
           Object.assign(this, binaryPackages(shasumData))
           return this
         }.bind(this))
+        .then(function (build) {
+          if (build.packageName || build.binaries.length) {
+            return build
+          }
+
+          return NullBuild(build)
+        })
       }
     }
   })

--- a/lib/build-node.js
+++ b/lib/build-node.js
@@ -57,7 +57,7 @@ module.exports = function (name, baseUri) {
         packageName: result[2]
       }
     } else {
-      throw new Error('bad checksum data', shasumData)
+      console.warn("Missing source package")
     }
   }
 

--- a/lib/build-null.js
+++ b/lib/build-null.js
@@ -1,0 +1,12 @@
+var Build = require('./build')().Build
+
+module.exports = function(build) {
+  return Object.create(build || Build, {
+    write: {
+      value: function(){
+        console.log(this.basename, 'skipped')
+        return Promise.resolve(this)
+      }
+    }
+  })
+}

--- a/lib/build.js
+++ b/lib/build.js
@@ -49,7 +49,7 @@ var Build = {
       write(path.join(dest, build.basename), build.definition, function (err) {
         if (err) return reject(err)
 
-        console.log(build.basename + ' written')
+        console.log(build.basename, 'written')
         resolve(build)
       })
     })

--- a/lib/scraper-nodejs-rcs.js
+++ b/lib/scraper-nodejs-rcs.js
@@ -1,7 +1,7 @@
 var Build = require('./build-node')('node', 'https://nodejs.org/download/rc/').Build
 
 module.exports = {
-  name: 'nodejs',
+  name: 'nodejs release candidate',
   distributionListing: 'https://nodejs.org/download/rc/index.json',
   distToBuild: function (release) {
     return Object.create(Build, {


### PR DESCRIPTION
This PR will allow build definitions to be written if a source package is missing _as long as there are corresponding binaries_.

The generated build file will contain a broken command for the source package:
```
install_package "undefined" "https://nodejs.org/download/rc/v6.0.0-rc.0/undefined.tar.gz#"
```

However, this at least allows the binary packages to be used. If a binary doesn't exist for the desired platform (or if source compilation is requested), then the install step will fail because `https://nodejs.org/download/rc/v6.0.0-rc.0/undefined.tar.gz` is an invalid URL.

This should be better addressed by: https://github.com/nodenv/node-build/issues/259


If there are no binary packages listed in the manifest (as well as no source package), then the build definition is skipped.