### PR TITLE
Stop matching headers

### DIFF
--- a/lib/build-node.js
+++ b/lib/build-node.js
@@ -57,7 +57,7 @@ module.exports = function (name, baseUri) {
   // private
 
   function sourcePackage (shasumData) {
-    var result = shasumData.match(/^(\w{64}) {2}(?:\.\/)?(node-v\d+\.\d+\.\d+(?:-rc\.\d+)?).tar.gz$/im)
+    var result = shasumData.match(/^(\w{64}) {2}(?:\.\/)?(node-v\d+\.\d+\.\d+(?:-rc\.\d+)?)\.tar\.gz$/im)
 
     if (result) {
       return {
@@ -71,7 +71,7 @@ module.exports = function (name, baseUri) {
 
   function binaryPackages (shasumData) {
     var matches = []
-    var regex = new RegExp(/^(\w{64}) {2}(?:\.\/)?((?:node-(v\d+\.\d+\.\d+(?:-rc\.\d+)?))-(.+)-(.+)).tar.gz$/gim)
+    var regex = new RegExp(/^(\w{64}) {2}(?:\.\/)?((?:node-(v\d+\.\d+\.\d+(?:-rc\.\d+)?))-([^.]+)-([^.]+))\.tar\.gz$/gim)
 
     var result
     while (result = regex.exec(shasumData)) {


### PR DESCRIPTION
Release candidate lines were being matched where the `rc.N` portion was
being applied as the OS while `headers` was being matched as the
architecture.

Now we are assuming that OSes and Architecture portions will never
contain a `.`; and also that the prerelease segment will _always_
contain a dot.