### PR TITLE
Adds scrapers for nightlies

### DIFF
--- a/bin/nodenv-update-version-defs
+++ b/bin/nodenv-update-version-defs
@@ -3,8 +3,8 @@
 # Summary: Create build definitions from nodejs.org
 #
 # Usage: nodenv update-version-defs [-f] [-d <dir>] [-n]
-#        [--nodejs] [--nodejs-pre]
-#        [--chakracore] [--chakracore-pre]
+#        [--nodejs] [--nodejs-pre] [--nodejs-nightly]
+#        [--chakracore] [--chakracore-pre] [--chakracore-nightly]
 #
 # Scrapes nodejs.org to create build definitions for node
 # versions not yet available to node-build
@@ -15,12 +15,15 @@
 #   -n/--dry-run       Print build definitions that would have been written;
 #                      without doing so
 #
-#   --nodejs           Scrape nodejs.org for node definitions;
-#   --nodejs-pre       Scrape nodejs.org for node pre-release definitions;
-#   --chakracore       Scrape nodejs.org for chakracore definitions;
-#   --chakracore-pre   Scrape nodejs.org for chakracore pre-release definitions;
-#                      Defaults to --nodejs, if none of:
-#                      --nodejs, --nodejs-pre, --chakracore, --chakracore-pre
+#   --nodejs              Scrape nodejs.org for node definitions;
+#   --nodejs-pre          Scrape nodejs.org for node pre-release definitions;
+#   --nodejs-nightly      Scrape nodejs.org for node nightly definitions;
+#   --chakracore          Scrape nodejs.org for chakracore definitions;
+#   --chakracore-pre      Scrape nodejs.org for chakracore pre-release definitions;
+#   --chakracore-nightly  Scrape nodejs.org for chakracore nightly definitions;
+#                         Defaults to --nodejs, if none of:
+#                         --nodejs, --nodejs-pre, --nodejs-nightly,
+#                         --chakracore, --chakracore-pre, --chakracore-nightly
 #
 # Notes: If this plugin is not installed directly into "$NODENV_ROOT/plugins",
 # (ie, homebrew, npm, etc) then 'share/node-build' must be added to the
@@ -73,8 +76,10 @@ while [ $# -gt 0 ]; do
       echo --force
       echo --nodejs
       echo --nodejs-pre
+      echo --nodejs-nightly
       echo --chakracore
       echo --chakracore-pre
+      echo --chakracore-nightly
       exit ;;
     -d | --destination )
       shift
@@ -82,8 +87,8 @@ while [ $# -gt 0 ]; do
       NODE_BUILD_DEFINITIONS="$(abs_dirname "${1%/}/"):${NODE_BUILD_DEFINITIONS}" ;;
     -f | --force | \
     -n | --dry-run | \
-    --nodejs | --nodejs-pre | \
-    --chakracore | --chakracore-pre )
+    --nodejs | --nodejs-pre | --nodejs-nightly | \
+    --chakracore | --chakracore-pre | --chakracore-nightly )
       SCRAPE_OPTS[${#SCRAPE_OPTS[*]}]="$1" ;;
     * )
       nodenv-help --usage update-version-defs >&2

--- a/lib/scraper-nodejs_org.js
+++ b/lib/scraper-nodejs_org.js
@@ -80,7 +80,7 @@ function wait (time) {
 }
 
 function sourcePackageFrom (shasumData) {
-  const regex = /^(\w{64}) {2}(?:\.\/)?(node-v\d+\.\d+\.\d+(?:-rc\.\d+)?)\.tar\.gz$/im
+  const regex = /^(\w{64}) {2}(?:\.\/)?(node-v\d+\.\d+\.\d+(?:(?:-rc\.\d+)|(?:-nightly\d{8}[0-9a-f]{10}))?)\.tar\.gz$/im
   const [, shasum, packageName] = regex.exec(shasumData) || []
 
   if (!packageName) console.warn('Missing source package')

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -14,6 +14,11 @@ const scrapers = {
     baseUri: 'https://nodejs.org/download/rc/'
   }),
 
+  '--nodejs-nightly': new NodejsOrgScraper({
+    displayName: 'nodejs nightly',
+    baseUri: 'https://nodejs.org/download/nightly/'
+  }),
+
   '--chakracore': new NodejsOrgScraper({
     name: 'chakracore',
     baseUri: 'https://nodejs.org/download/chakracore-release/'
@@ -23,6 +28,12 @@ const scrapers = {
     name: 'chakracore',
     displayName: 'chakracore release candidate',
     baseUri: 'https://nodejs.org/download/chakracore-rc/'
+  }),
+
+  '--chakracore-nightly': new NodejsOrgScraper({
+    name: 'chakracore',
+    displayName: 'chakracore nightly',
+    baseUri: 'https://nodejs.org/download/chakracore-nightly/'
   })
 }
 
@@ -48,8 +59,10 @@ process.argv.forEach(arg => {
       break
     case '--nodejs':
     case '--nodejs-pre':
+    case '--nodejs-nightly':
     case '--chakracore':
     case '--chakracore-pre':
+    case '--chakracore-nightly':
       scrapersToRun.push(arg)
       break
   }


### PR DESCRIPTION
This is effectively blocked by https://github.com/nodenv/node-build/issues/259

because the nodejs nightlies only contain compiled binaries.

Open question: should the nightlies be included in the
https://github.com/nodenv/node-build-prerelease plugin or its own
separate plugin? (I'm leaning towards the former)