### PR TITLE
Adds pattern option to filter written defs

### DIFF
--- a/bin/nodenv-update-version-defs
+++ b/bin/nodenv-update-version-defs
@@ -2,7 +2,7 @@
 #
 # Summary: Create build definitions from nodejs.org
 #
-# Usage: nodenv update-version-defs [-f] [-d <dir>] [-n]
+# Usage: nodenv update-version-defs [-f] [-d <dir>] [-e <pattern> ] [-n]
 #        [--nodejs] [--nodejs-pre] [--nodejs-nightly]
 #        [--chakracore] [--chakracore-pre] [--chakracore-nightly]
 #
@@ -10,6 +10,8 @@
 # versions not yet available to node-build
 #
 #   -d/--destination   Directory where build definitions will be written
+#   -e/--regexp        Only write definitions whose basename patches the pattern.
+#                      Useful with -f to force overwrite a subset of definitions.
 #   -f/--force         Write build definitions that already exist somewhere in
 #                      NODE_BUILD_DEFINITIONS paths; possibly overwriting
 #   -n/--dry-run       Print build definitions that would have been written;
@@ -74,6 +76,7 @@ while [ $# -gt 0 ]; do
       echo --destination
       echo --dry-run
       echo --force
+      echo --regexp
       echo --nodejs
       echo --nodejs-pre
       echo --nodejs-nightly
@@ -85,11 +88,14 @@ while [ $# -gt 0 ]; do
       shift
       # overwrite the defs write target
       NODE_BUILD_DEFINITIONS="$(abs_dirname "${1%/}/"):${NODE_BUILD_DEFINITIONS}" ;;
+    -e | --regexp)
+      SCRAPE_OPTS+=("$1" "$2")
+      shift ;;
     -f | --force | \
     -n | --dry-run | \
     --nodejs | --nodejs-pre | --nodejs-nightly | \
     --chakracore | --chakracore-pre | --chakracore-nightly )
-      SCRAPE_OPTS[${#SCRAPE_OPTS[*]}]="$1" ;;
+      SCRAPE_OPTS+=("$1") ;;
     * )
       nodenv-help --usage update-version-defs >&2
       exit 1;;

--- a/lib/definition-file.js
+++ b/lib/definition-file.js
@@ -2,9 +2,12 @@ const fs = require('fs')
 const path = require('path')
 
 module.exports = class DefinitionFile {
-  static configure ({ dryRun, overwrite, definitionPaths }) {
+  static configure ({ dryRun, overwrite, pattern, definitionPaths }) {
     this.destDir = definitionPaths[0]
     this.writer = dryRun ? this.dryRunWriter : this.fsWriter
+    this.matching = pattern
+      ? definitionFile => definitionFile.matches(pattern)
+      : () => true
     this.toWrite = overwrite
       ? () => true
       : definitionFile => !definitionFile.existsIn(definitionPaths)
@@ -44,6 +47,10 @@ module.exports = class DefinitionFile {
 
   existsIn (dirs) {
     return dirs.some(dir => fs.existsSync(this.filename(dir)))
+  }
+
+  matches (pattern) {
+    return this.basename.match(pattern)
   }
 
   write (write, definition) {

--- a/lib/scraper-nodejs_org.js
+++ b/lib/scraper-nodejs_org.js
@@ -56,6 +56,7 @@ module.exports = class NodejsOrgScraper extends Scraper {
             version: release.version
           })
       )
+      .filter(DefinitionFile.matching)
       .filter(DefinitionFile.toWrite)
   }
 

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -47,8 +47,12 @@ const options = {
   ).split(':')
 }
 
-process.argv.forEach(arg => {
+process.argv.forEach((arg, i, argv) => {
   switch (arg) {
+    case '-e':
+    case '--regexp':
+      options.pattern = argv[i + 1]
+      break
     case '-f':
     case '--force':
       options.overwrite = true


### PR DESCRIPTION
Want to only write a certain subset of definitions?
Or even more useful: when force-writing (overwriting or dupe-writing),
limit the written defs to those that match the pattern.

closes #27 