### PR TITLE
Generate binary-only definitions

### DIFF
--- a/lib/definition.js
+++ b/lib/definition.js
@@ -2,18 +2,20 @@ module.exports = class Definition {
   constructor (props) {
     Object.assign(this, props)
 
-    // TODO: only guard if missing both source and binaries
-    // once we're able to build a binary-only package:
-    // https://github.com/nodenv/node-build/issues/259
-    if (!this.packageName) throw Error('skipping')
+    if (!this.packageName && !this.binaries.length) throw Error('skipping')
   }
 
   get preamble () {
-    return ''
+    return this.packageName
+      ? ''
+      : 'echo "This package only contains compiled binaries."\n' +
+          'echo "If no binary matches your platform, source compilation will not be attempted."\n'
   }
 
   get install () {
-    return `install_package "${this.packageName}" "${this.downloadUri}"`
+    return this.packageName
+      ? `install_package "${this.packageName}" "${this.downloadUri}"`
+      : `install_package "${this.version}"`
   }
 
   get postamble () {


### PR DESCRIPTION
node-build can quietly handle binary-only releases. It's only if the
binary installation fails is there a problem.

#29 