### PR TITLE
Adds submit/verify scripts

### DIFF
--- a/script/submit-definitions
+++ b/script/submit-definitions
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# scrapes, commits, pushes, and pull-requests new node definitions
+#
+# Usage: script/update-nodes [-o ORIGIN] [-r FORK]
+#
+# Options:
+#   -o ORIGIN    The remote to which the pull-request will be opened.
+#                [default: origin]
+#   -r FORK      The remote to which scraped definitions will be pushed.
+#                [default: derived from hub-fork]
+#                (Empty-string is a shortcut for 'origin': `-r ''`.)
+#
+# Notes: inspired by https://github.com/jasonkarns/brew-publish
+
+set -eufo pipefail
+IFS=$'\n\t'
+
+abort() {
+  echo "$1" >&2
+  exit 1
+}
+
+if ! type -p hub >/dev/null; then
+  abort "ERROR: You have to install hub to proceed."
+fi
+
+while getopts ":o:r:" opt; do
+  case $opt in
+  o) origin="${OPTARG}" ;;
+  r) fork="${OPTARG:-origin}" ;;
+  :) abort "Option -$OPTARG requires an argument." ;;
+  \?) abort "Invalid option: -$OPTARG" ;;
+  esac
+done
+
+: "${origin:=origin}"
+# hackish way of getting the git remote name for user's fork
+: "${fork:=$(hub fork 2>&1 | grep -oE 'remote:? \S+' | tail -1 | awk '{print $2}')}"
+
+# This returns 'HEAD' if in detached HEAD state. Useless in that case.
+orig_branch=$(git rev-parse --abbrev-ref HEAD)
+
+git fetch --quiet --unshallow "$origin" master 2>/dev/null || git fetch --quiet "$origin" master
+
+git checkout --quiet "$origin"/master
+
+npm run-script scrape-definitions
+
+for node_def in $(git ls-files --others --exclude-standard -- share/node-build/); do
+  node_name="$(basename "$node_def")"
+
+  git checkout --quiet -B "node/$node_name" "$origin"/master
+  git add -- "$node_def"
+  git commit --message "$node_name" --message "Created with \`npm run submit-definitions\`." --only -- "$node_def"
+  git push --set-upstream "$fork" HEAD
+  hub pull-request --message="$(git log -1 --format='%B')"
+  git checkout --quiet -
+done
+
+git checkout --quiet "$orig_branch"

--- a/script/verify-definitions
+++ b/script/verify-definitions
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Usage: script/verify-definitions (- | -- FILES... | COMMIT_RANGE)
+#   script/verify-definitions -             # verify definition files listed on STDIN
+#   script/verify-definitions -- foo        # verify specific files by name
+#   script/verify-definitions COMMIT_RANGE  # verify definitions modified in COMMIT_RANGE
+
+set -eufo pipefail
+IFS=$'\n\t'
+
+help_text() {
+  sed -ne '/^#/!q;s/.\{1,2\}//;1d;p' < "$0"
+}
+
+compute_sha2() {
+  local output
+  output="$(openssl dgst -sha256)"
+  echo "${output##* }" | tr '[:upper:]' '[:lower:]'
+}
+
+download_package() {
+  curl -qsSfL -o "$2" "$1"
+}
+
+download_and_verify() {
+  local checksum
+  local url="$1"
+  local file="$2"
+  local expected="$3"
+  download_package "$url" "$file" || return $?
+  checksum="$(compute_sha2 < "$file")"
+  if [ "$checksum" != "$expected" ]; then
+    {
+      echo "Error: $url doesn't match its checksum:"
+      echo "  expected: $expected"
+      echo "    actual: $checksum"
+    } >&2
+    return 1
+  fi
+}
+
+changed_files() {
+  local commit_range="$1"
+  git diff --name-only --diff-filter=ACMR "$commit_range" -- ./share/node-build
+}
+
+extract_urls() {
+  $(type -p ggrep grep | head -1) -hoEe 'http[^"]+#[^"]*' | sort | uniq
+}
+
+verify_files() {
+  xargs cat | extract_urls
+}
+
+potentially_new_packages() {
+  local commit_range="$1"
+
+  changed_files "$commit_range"
+}
+
+verify() {
+  local url checksum file status=0
+  while read -r url; do
+    checksum="${url#*#}"
+    url="${url%#*}"
+    echo "Verifying checksum for $url"
+    file="${TMPDIR:-/tmp}/$checksum"
+    download_and_verify "$url" "$file" "$checksum" || (( status += 1))
+  done < <(xargs cat | extract_urls)
+
+  if [ "$status" != 0 ]; then
+    echo "failures: $status"
+    return 1
+  fi
+}
+
+case "${1-}" in
+  '' )
+    { echo "COMMIT_RANGE or FILES required"
+      help_text
+    } >&2
+    exit 1;;
+  -h | --help )
+    help_text
+    ;;
+  - )
+    verify
+    ;;
+  -- )
+    echo "$@" | verify
+    ;;
+  * )
+    echo "Verifying changes from $1"
+    changed_files "$1"
+    potentially_new_packages "$1" | verify
+    ;;
+esac


### PR DESCRIPTION
Scripty (which is used by most nodenv plugins) supports the sharing of
scripts via node module.

Most node-build plugins which leverage _this_ plugin, have submit
scripts which push the scraped definitions to github. As well as verify
scripts which validate the scraped package URLs on travis.

These scripts are manually maintained between the node-build plugin
repos. Sharing them within this package (which is itself the cornerstone
of the node-build plugins' scripts in the first place) seems logical.