### PR TITLE
Better messaging for skipped defs

### DIFF
--- a/lib/definition-file.js
+++ b/lib/definition-file.js
@@ -57,6 +57,6 @@ module.exports = class DefinitionFile {
     return Promise.resolve(definition)
       .then(contents => write(this.filename(), contents.toString()))
       .then(() => console.log(this.basename, 'written'))
-      .catch(e => console.error(this.basename, 'skipped'))
+      .catch(e => console.error(`${this.basename} skipped (${e})`))
   }
 }

--- a/lib/definition.js
+++ b/lib/definition.js
@@ -2,7 +2,9 @@ module.exports = class Definition {
   constructor (props) {
     Object.assign(this, props)
 
-    if (!this.packageName && !this.binaries.length) throw Error('skipping')
+    if (!this.packageName && !this.binaries.length) {
+      throw Error('no source or binaries')
+    }
   }
 
   get preamble () {

--- a/lib/scraper-nodejs_org.js
+++ b/lib/scraper-nodejs_org.js
@@ -84,8 +84,6 @@ function sourcePackageFrom (shasumData) {
   const regex = /^(\w{64}) {2}(?:\.\/)?(node-v\d+\.\d+\.\d+(?:(?:-rc\.\d+)|(?:-nightly\d{8}[0-9a-f]{10}))?)\.tar\.gz$/im
   const [, shasum, packageName] = regex.exec(shasumData) || []
 
-  if (!packageName) console.warn('Missing source package')
-
   return { packageName, shasum }
 }
 


### PR DESCRIPTION
If a package is missing _both_ source tarball and has no applicable
binaries, throw a more descriptive error.

If catching an error during writing, print that error for details.
(like, the fact that it was skipped due to missing both source +
binaries)

Lastly, remove the warning message during parsing about missing source
package. Better to allow that printed at the time it's skipped.