### PR TITLE
Fix GraalVM scraper

### DIFF
--- a/bin/nodenv-update-version-defs
+++ b/bin/nodenv-update-version-defs
@@ -25,7 +25,7 @@
 #   --chakracore-pre      Scrape nodejs.org for chakracore pre-release definitions;
 #   --chakracore-nightly  Scrape nodejs.org for chakracore nightly definitions;
 #   --graal               Scrape github.com for graalvm definitions;
-#                         Defaults to --nodejs, if given
+#                         Defaults to --nodejs, if none given
 #
 # Notes: If this plugin is not installed directly into "$NODENV_ROOT/plugins",
 # (ie, homebrew, npm, etc) then 'share/node-build' must be added to the

--- a/lib/definition-graal.js
+++ b/lib/definition-graal.js
@@ -11,8 +11,9 @@ module.exports = class GraalDefinition extends Definition {
   static platformFrom (url) {
     return {
       linux: 'linux-x64',
-      macos: 'darwin-x64'
-    }[/-(macos|linux)-amd64/.exec(url)[1]]
+      macos: 'darwin-x64',
+      darwin: 'darwin-x64'
+    }[/-(macos|darwin|linux)-amd64/.exec(url)[1]]
   }
 
   get packageName () {

--- a/lib/definition-graal.js
+++ b/lib/definition-graal.js
@@ -2,10 +2,13 @@ const Definition = require('./definition')
 
 module.exports = class GraalDefinition extends Definition {
   static Binary (definition) {
-    return ({ url, sha }) => ({
-      platform: this.platformFrom(url),
-      downloadUri: `${url}#${sha}`
-    })
+    return ({ url, sha }) =>
+      url.match(/\.tar\.gz$/)
+        ? {
+          platform: this.platformFrom(url),
+          downloadUri: `${url}#${sha}`
+        }
+        : null
   }
 
   static platformFrom (url) {

--- a/lib/definition.js
+++ b/lib/definition.js
@@ -6,7 +6,9 @@ module.exports = class Definition {
       throw Error('no source or binaries')
     }
 
-    this.binaries = (this.binaries || []).map(this.constructor.Binary(this))
+    this.binaries = (this.binaries || [])
+      .map(this.constructor.Binary(this))
+      .filter(b => b)
   }
 
   get noSource () {


### PR DESCRIPTION
Latest Graal releases have changed their asset url format and broken the
scraper.

Firstly, they've started using `darwin` in the filename instead of `macos` to indicate the platform.

Secondly, they've started including windows builds (.zip) and native builds (.jars) that we don't yet support. We need to skip those assets for now.