### PR TITLE
Learn to run the LTS message linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postinstall": "script/postinstall",
     "clean": "git clean -f -- share",
     "defs:scrape": "npm start -- ",
+    "defs:lint:lts": "script/lts-lint-definitions",
     "defs:commit": "script/commit-definitions",
     "defs:submit": "script/submit-definitions",
     "defs:verify": "script/verify-definitions",

--- a/script/commit-definitions
+++ b/script/commit-definitions
@@ -6,6 +6,9 @@
 #
 # Notes: extracted from https://github.com/nodenv/node-build-update-defs/blob/ac8e155cd8df843ca224c45ef55a36e20719bf9d/script/submit-definitions
 
+set -eufo pipefail
+IFS=$'\n\t'
+
 # change to repo-root;
 # allows the script to be invoked via `npm explore -- npm run defs:commit`
 # however, it will fail if this package is installed as a git-dep

--- a/script/lts-lint-definitions
+++ b/script/lts-lint-definitions
@@ -86,8 +86,8 @@ prepend_message() {
   local msg=${!1}
   local file=$2
 
-  sed -i'' -e "1 i\\
-$msg" "$file"
+  sed -e "1 i\\
+$msg" "$file" 1<> "$file"
 }
 
 assert_message() {

--- a/script/lts-lint-definitions
+++ b/script/lts-lint-definitions
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# asserts definitions contain the appropriate warning message per the LTS schedule
+#
+# Usage: script/lts-lint-definitions
+#
+# Options:
+#
+# Output:
+#   failing definition filenames to STDOUT
+#   status messages to STDERR
+
+set -euo pipefail
+IFS=$'\n\t'
+
+FIX=
+DIR=share/node-build
+TODAY=$(date -u +'%F')
+
+for arg in "$@"; do
+  case "$arg" in
+    --fix) FIX=1;;
+    *) DIR=$arg;;
+  esac
+done
+
+# shellcheck disable=2034
+eol_WARNING="before_install_package() {\\
+\  build_package_warn_eol \"\$1\"\\
+}\\
+\\
+"
+# shellcheck disable=2034
+lts_WARNING="before_install_package() {\\
+\  build_package_warn_lts_maintenance \"\$1\"\\
+}\\
+\\
+"
+
+schedule_json() {
+  curl -qsSfJL https://raw.githubusercontent.com/nodejs/Release/master/schedule.json
+}
+
+# Flattens the LTS schedule.json into bash variables:
+# eg:
+#   v4_start="2015-09-08"
+#   v4_lts="2015-10-12"
+#   v4_maintenance="2017-04-01"
+#   v4_end="2018-04-30"
+#   v4_codename="Argon"
+# and creates a 'versions' array of the versions to check.
+# The output should be eval'd to make the variables available to this script.
+parse_json() {
+  awk '
+  /"v[[:digit:]]+":/ {
+    gsub(/[^[:digit:].]/, "")
+    version = $0
+    print "versions+=(" version ")"
+    next
+  }
+
+  /".*":/ && version {
+    gsub(/[ "]/, "")
+    gsub(/,$/, "")
+    split($0, v, /:/)
+
+    print "v" version "_" v[1] "=\"" v[2] "\""
+    next
+  }
+
+  /}/ {
+    version = 0
+    next
+  }
+'
+}
+
+past() {
+  [[ "$1" < "$TODAY" ]]
+}
+
+prepend_message() {
+  local msg=${!1}
+  local file=$2
+
+  sed -i'' -e "1 i\\
+$msg" "$file"
+}
+
+assert_message() {
+  local stage=$1
+  local v=$2
+  local msg_var=${stage}_WARNING
+
+  echo "asserting $stage message for v$v" >&2
+
+  grep -e "warn_$stage" --files-without-match "${DIR%/}/$v".* | while read -r file; do
+    echo "$file"
+    if [ -n "$FIX" ]; then
+      prepend_message "${msg_var}" "$file"
+    fi
+    false # execution of this loop indicates failure; must force nonzero exit
+  done
+}
+
+assert_warnings() {
+  local status=0
+
+  for version in "${versions[@]}"; do
+    local eol_date_var="v${version}_end"
+    local maint_date_var="v${version}_maintenance"
+
+    local eol_date=${!eol_date_var}
+    local maint_date=${!maint_date_var}
+
+    echo "v$version maint: $maint_date eol: $eol_date" >&2
+    {
+      if past "$eol_date"; then assert_message eol "$version"
+      elif past "$maint_date"; then assert_message lts "$version"
+      fi
+    } || status=$?
+  done
+
+  return $status
+}
+
+declare -a versions
+eval "$(schedule_json | parse_json)"
+
+assert_warnings

--- a/script/lts-lint-definitions
+++ b/script/lts-lint-definitions
@@ -95,8 +95,6 @@ assert_message() {
   local v=$2
   local msg_var=${stage}_WARNING
 
-  echo "asserting $stage message for v$v" >&2
-
   grep -e "warn_$stage" --files-without-match "${DIR%/}/$v".* | while read -r file; do
     echo "$file"
     if [ -n "$FIX" ]; then

--- a/script/lts-lint-definitions
+++ b/script/lts-lint-definitions
@@ -2,13 +2,16 @@
 
 # asserts definitions contain the appropriate warning message per the LTS schedule
 #
-# Usage: script/lts-lint-definitions
+# Usage: script/lts-lint-definitions [--fix] [DIR]
 #
 # Options:
+#   --fix   Fix violations by inserting the necessary warning message.
+#   DIR     Directory of definitions to lint (default: share/node-build/)
 #
 # Output:
 #   failing definition filenames to STDOUT
 #   status messages to STDERR
+#
 
 set -euo pipefail
 IFS=$'\n\t'


### PR DESCRIPTION
Inherits the LTS lint script from node-build.
Tweaks script to be less noisy and avoid the sed/gsed incompatibility
w.r.t. `-i` options.

Complication is the CWD of the script. Normally expected to be run from
the root of node-build (thus share/node-build/ is relative). However,
it's now expected to be run via `npm explore -- npm run ...`. Thus the
CWD is now this package's directory within node_modules. The other
scripts here are temporarily using a hack to cd to git-repo root. But
this only works as long as this package isn't installed as a git dep or
npm-linked. (In both cases, this package itself is a git-repo-root, so
that hack doesn't work.) To avoid the issue entirely, this script now
expects the definition directory to be passed explicitly. It still has a
default but that would likely fail most invocations.