### PR TITLE
Don't attempt to control the node runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
 /node_modules
 /nodenv-node-build-update-defs-*.tgz
-
-# normally, it's okay for node-version to be committed
-# but since it would effect users of the plugin,
-# we can't allow it to get committed
-/.node-version

--- a/bin/nodenv-update-version-defs
+++ b/bin/nodenv-update-version-defs
@@ -117,15 +117,12 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# change to plugin dir so .node-version will be respected
-cd "$INSTALL_PREFIX"
-
 node - <<-JS
-require('./')({
+require('${INSTALL_PREFIX:?}/')({
   dryRun: ${DRY_RUN:-false},
   overwrite: ${FORCE:-false},
   pattern: RegExp('${PATTERN}'),
   run: [ $(printf '"%s",' "${SCRAPERS[@]:-nodejs}") ],
-  definitionPaths: '${NODE_BUILD_DEFINITIONS:-share/node-build}'.split(':')
+  definitionPaths: '${NODE_BUILD_DEFINITIONS:-$INSTALL_PREFIX/share/node-build}'.split(':')
 })
 JS


### PR DESCRIPTION
Attempting to pin to a node adds complexity where the user must install
that version. It then also presumes the same nodenv configuration
(plugins, etc).

Instead, just invoke node and presume that it works. Node 6 has been out
long enough that we shouldn't have version compatibility issues.
